### PR TITLE
Removed backView because of bug: cell contentView becomes transparent and shows backView behind.

### DIFF
--- a/ZKRevealingTableViewCell.podspec
+++ b/ZKRevealingTableViewCell.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = 'ZKRevealingTableViewCell'
+  s.version      = '0.0.3'
+  s.license      = 'MIT'
+  s.summary      = 'A Sparrow-style Implementation of Swipe-To-Reveal.'
+  s.homepage     = 'https://github.com/alexzielenski/ZKRevealingTableViewCell'
+  s.author       = { 'Alex Zielenski' => 'support@alexzielenski.com' }
+  s.source       = { :git => 'https://github.com/alexzielenski/ZKRevealingTableViewCell.git', :tag => '0.0.3' }
+  s.description  = 'A different kind of swipe-to-reveal that pans with your finger and works left and right to reveal a background view.'
+  s.platform     = :ios
+  s.source_files = 'vendor'
+
+  s.framework    = 'QuartzCore'
+end

--- a/vendor/ZKRevealingTableViewCell.h
+++ b/vendor/ZKRevealingTableViewCell.h
@@ -45,8 +45,6 @@ typedef enum {
 @end
 
 @interface ZKRevealingTableViewCell : UITableViewCell
-
-@property (nonatomic, retain) IBOutlet UIView *backView;
 @property (nonatomic, assign, getter = isRevealing) BOOL revealing;
 @property (nonatomic, assign) id <ZKRevealingTableViewCellDelegate> delegate;
 @property (nonatomic, assign) ZKRevealingTableViewCellDirection direction;

--- a/vendor/ZKRevealingTableViewCell.m
+++ b/vendor/ZKRevealingTableViewCell.m
@@ -68,7 +68,6 @@
 @synthesize delegate     = _delegate;
 @synthesize shouldBounce = _shouldBounce;
 @synthesize pixelsToReveal = _pixelsToReveal;
-@synthesize backView     = _backView;
 
 #pragma mark - Lifecycle
 
@@ -84,12 +83,6 @@
 		self._panGesture.delegate = self;
 		
 		[self addGestureRecognizer:self._panGesture];
-		
-		self.contentView.backgroundColor = [UIColor clearColor];
-		
-		UIView *backgroundView         = [[[UIView alloc] initWithFrame:self.contentView.frame] autorelease];
-		backgroundView.backgroundColor = [UIColor clearColor];
-		self.backView                  = backgroundView;
     }
     return self;
 }
@@ -106,12 +99,6 @@
 		self._panGesture.delegate = self;
 		
 		[self addGestureRecognizer:self._panGesture];
-		
-		self.contentView.backgroundColor = [UIColor clearColor];
-		
-		UIView *backgroundView         = [[[UIView alloc] initWithFrame:self.contentView.frame] autorelease];
-		backgroundView.backgroundColor = [UIColor clearColor];
-		self.backView                  = backgroundView;
     }
     return self;
 }
@@ -119,17 +106,7 @@
 - (void)dealloc
 {
 	self._panGesture = nil;
-	self.backView    = nil;
 	[super dealloc];
-}
-
-- (void)layoutSubviews
-{
-	[super layoutSubviews];
-	
-	[self addSubview:self.backView];
-	[self addSubview:self.contentView];
-	self.backView.frame = self.contentView.frame;
 }
 
 #pragma mark - Accessors


### PR DESCRIPTION
Completely removed backView because we already have backgroundView in
UITableViewCell and can use it as revealed view. And using backView as
it was used interfered with selectedBackgroundView, so cell contentView
always becomes transparent and shows contents of backView. And we can't use custom cell selection effect. This is fixed now.
This patch may break use of IB to connect backView to cell. I don't use IB in my projects, so I can't check it. I guess this could be fixed by redefining backgroundView property as IBOutlet.
